### PR TITLE
fix no such method exception

### DIFF
--- a/android/src/main/java/com/cree/usbserial/UsbSerialPlugin.java
+++ b/android/src/main/java/com/cree/usbserial/UsbSerialPlugin.java
@@ -199,9 +199,11 @@ public class UsbSerialPlugin implements MethodCallHandler, EventChannel.StreamHa
         HashMap<String, Object> dev = new HashMap<>();
         dev.put("vid", device.getVendorId());
         dev.put("pid", device.getProductId());
-        dev.put("manufacturerName", device.getManufacturerName());
-        dev.put("productName", device.getProductName());
-        dev.put("serialNumber", device.getSerialNumber());
+        if (android.os.Build.VERSION.SDK_INT >= 21) {
+            dev.put("manufacturerName", device.getManufacturerName());
+            dev.put("productName", device.getProductName());
+            dev.put("serialNumber", device.getSerialNumber());
+        }
         dev.put("deviceId", device.getDeviceId());
         return dev;
     }


### PR DESCRIPTION
if android api level lower than 21
will throw NoSuchMethodException.

[UsbDevice#getManufacturerName() API level](https://developer.android.com/reference/android/hardware/usb/UsbDevice.html#getManufacturerName())