### PR TITLE
fix Android 10 SecurityException 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
+++ b/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
@@ -199,10 +199,14 @@ public class UsbSerialPlugin implements MethodCallHandler, EventChannel.StreamHa
         HashMap<String, Object> dev = new HashMap<>();
         dev.put("vid", device.getVendorId());
         dev.put("pid", device.getProductId());
-        if (android.os.Build.VERSION.SDK_INT >= 21) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
             dev.put("manufacturerName", device.getManufacturerName());
             dev.put("productName", device.getProductName());
-            dev.put("serialNumber", device.getSerialNumber());
+            /* if the app targets SDK >= android.os.Build.VERSION_CODES.Q and the app does not have permission to read from the device. */
+            try {
+                dev.put("serialNumber", device.getSerialNumber());
+            } catch  ( java.lang.SecurityException e ) {
+            }
         }
         dev.put("deviceId", device.getDeviceId());
         return dev;


### PR DESCRIPTION
fix issues #19 

[https://developer.android.com/reference/android/hardware/usb/UsbDevice.html#getSerialNumber()](https://developer.android.com/reference/android/hardware/usb/UsbDevice.html#getSerialNumber())


Throws SecurityException. If the app targets SDK >= android.os.Build.VERSION_CODES.Q and the app does not have permission to read from the device.

