### PR TITLE
Fixed build.gradle for newer android/gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,8 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 33
+    
+    namespace 'dev.bessems.usbserial'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
In my environment compiling with anything greater than `0.4.0` of usbserial causes this error:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':usb_serial:generateReleaseBuildConfig'.
> Error while evaluating property 'namespace' of task ':usb_serial:generateReleaseBuildConfig'
   > Failed to calculate the value of task ':usb_serial:generateReleaseBuildConfig' property 'namespace'.
      > Failed to calculate the value of property 'namespace'.
         > Package Name not found in /home/my_user/.pub-cache/hosted/pub.dev/usb_serial-0.5.1/android/src/main/AndroidManifest.xml, and namespace not specified. Please specify a namespace for the generated R and BuildConfig classes via android.namespace in the module's build.gradle file like so:

           android {
               namespace 'com.example.namespace'
           }



* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
Running Gradle task 'assembleRelease'...                            3.8s
Gradle task assembleRelease failed with exit code 1
```

This fixes that error.


If this is not merged, you can use this fork like:
```
  usb_serial:
    git:
      url: https://github.com/ChaseGuru/usbserial.git
```