### PR TITLE
fix: Android 14 compability

### DIFF
--- a/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
+++ b/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
@@ -105,6 +105,7 @@ public class UsbSerialPlugin implements FlutterPlugin, MethodCallHandler, EventC
         void onSuccess(UsbDevice device);
         void onFailed(UsbDevice device);
     }
+    @SuppressLint("PrivateApi")
     private void acquirePermissions(UsbDevice device, AcquirePermissionCallback cb) {
 
         class BRC2 extends  BroadcastReceiver {
@@ -148,7 +149,19 @@ public class UsbSerialPlugin implements FlutterPlugin, MethodCallHandler, EventC
             flags = PendingIntent.FLAG_MUTABLE;
         }
 
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(cw, 0, new Intent(ACTION_USB_PERMISSION), flags);
+        Intent intent = new Intent(ACTION_USB_PERMISSION);
+
+        Class<?> activityThread = null;
+        try {
+            activityThread = Class.forName("android.app.ActivityThread");
+            Method method = activityThread.getDeclaredMethod("currentPackageName");
+            String appPackageName = (String) method.invoke(activityThread);
+            intent.setPackage(appPackageName);
+        } catch (Exception e) {
+            // Not too important to throw anything
+        }
+
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(cw, 0, intent, flags);
 
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
 

--- a/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
+++ b/android/src/main/java/dev/bessems/usbserial/UsbSerialPlugin.java
@@ -1,5 +1,6 @@
 package dev.bessems.usbserial;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -13,6 +14,7 @@ import android.util.Log;
 
 import com.felhr.usbserial.UsbSerialDevice;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;


### PR DESCRIPTION
Android 14 introduced some changes to intents:
https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents

If you will build app that targets Android 14 (SDK 34) it will throw error on connection:
java.lang.IllegalArgumentException: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.