### PR TITLE
Introducing magicHeaderFixedLength class 

### DIFF
--- a/lib/transaction.dart
+++ b/lib/transaction.dart
@@ -65,6 +65,20 @@ class Transaction<T> {
             header: header, maxLen: maxLen));
   }
 
+  /// Create a transaction that uses MagicHeaderFixedLengthByteTransformer
+  ///
+  /// ```dart
+  /// Transaction.magicHeaderFixedLength(p.inputStream, Uint8List.fromList([65,65,65]), len: 10); // expects magic header AAA and fixed length 10.
+  /// ```
+  static Transaction<Uint8List> magicHeaderFixedLength(
+      Stream<Uint8List> stream, List<int> header, int len,
+      {int maxLen = 1024}) {
+    return Transaction<Uint8List>(
+        stream,
+        MagicHeaderFixedLengthByteTransformer.broadcast(
+            header: header, len: len, maxLen: maxLen));
+  }
+
   /// Create a transaction that transforms the incoming stream into
   /// events delimited by 'terminator', returning Strings.
   ///

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -437,14 +437,14 @@ class MagicHeaderFixedLengthByteTransformer
         _partial = _partial.sublist(index);
       }
 
-      if (_partial.length < header!.length + len) {
+      if (_partial.length < header!.length + len + 1) {
         // not completely arrived yet.
         return;
       }
 
       _controller
-          .add(Uint8List.fromList(_partial.sublist(0, len + header!.length)));
-      _partial = _partial.sublist(len + header!.length);
+          .add(Uint8List.fromList(_partial.sublist(0, len + header!.length + 1)));
+      _partial = _partial.sublist(len + header!.length + 1);
     }
   }
 }

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -342,7 +342,7 @@ class MagicHeaderAndLengthByteTransformer
       }
 
       // int len = _partial[header!.length];
-      int len = 75;
+      int len = 74;
       if (_partial.length < len + header!.length + 1) {
         // not completely arrived yet.
         return;

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -341,8 +341,7 @@ class MagicHeaderAndLengthByteTransformer
         return;
       }
 
-      // int len = _partial[header!.length];
-      int len = 74;
+      int len = _partial[header!.length];
       if (_partial.length < len + header!.length + 1) {
         // not completely arrived yet.
         return;
@@ -384,5 +383,68 @@ class MagicHeaderAndLengthByteTransformer
   @override
   void dispose() {
     _controller.close();
+  }
+}
+
+class MagicHeaderFixedLengthByteTransformer
+    extends MagicHeaderAndLengthByteTransformer {
+  final int len;
+
+  MagicHeaderFixedLengthByteTransformer(
+      {bool sync = false,
+      bool? cancelOnError,
+      List<int?>? header,
+      required this.len,
+      int maxLen = 1024,
+      Duration clearTimeout = const Duration(seconds: 1)})
+      : super(
+            sync: sync,
+            cancelOnError: cancelOnError,
+            header: header,
+            maxLen: maxLen,
+            clearTimeout: clearTimeout);
+
+  MagicHeaderFixedLengthByteTransformer.broadcast(
+      {bool sync = false,
+      bool? cancelOnError,
+      List<int?>? header,
+      required this.len,
+      int maxLen = 1024,
+      Duration clearTimeout = const Duration(seconds: 1)})
+      : super.broadcast(
+            sync: sync,
+            cancelOnError: cancelOnError,
+            header: header,
+            maxLen: maxLen,
+            clearTimeout: clearTimeout);
+
+  @override
+  void onData(Uint8List data) {
+    _dataSinceLastTick = true;
+    if (_partial.length > maxLen) {
+      _partial = _partial.sublist(_partial.length - maxLen);
+    }
+
+    _partial.addAll(data);
+
+    while (_partial.length > 0) {
+      int index = wildcardFind(header, _partial);
+      if (index < 0) {
+        return;
+      }
+
+      if (index > 0) {
+        _partial = _partial.sublist(index);
+      }
+
+      if (_partial.length < header!.length + len) {
+        // not completely arrived yet.
+        return;
+      }
+
+      _controller
+          .add(Uint8List.fromList(_partial.sublist(0, len + header!.length)));
+      _partial = _partial.sublist(len + header!.length);
+    }
   }
 }

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -341,7 +341,8 @@ class MagicHeaderAndLengthByteTransformer
         return;
       }
 
-      int len = _partial[header!.length];
+      // int len = _partial[header!.length];
+      int len = 75;
       if (_partial.length < len + header!.length + 1) {
         // not completely arrived yet.
         return;


### PR DESCRIPTION
Instead of reading the data stream to determine the message length, as in MagicHeaderAndLengthByteTransformer, the new MagicHeaderFixedLengthByteTransformer takes in an integer variable `len` to read messages of a fixed length that are preceded by a "magic header" string.