### PR TITLE
Fix Jitpack import issue for UsbSerial dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.felHR85:UsbSerial:6.1.0'
+    implementation('com.github.felHR85:UsbSerial:7ad6c9f6') {
+        artifact {
+            classifier = 'release'
+            type = 'aar'
+        }
+    }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,7 @@ android {
 }
 
 dependencies {
+    // TODO: Temporary workaround, need to switch to stable release tag when UsbSerial builds successfully.
     implementation('com.github.felHR85:UsbSerial:7ad6c9f6') {
         artifact {
             classifier = 'release'


### PR DESCRIPTION
As a temporary workaround, I used import the latest successful build hash tag ([7ad6c9f6](https://jitpack.io/com/github/felHR85/UsbSerial/7ad6c9f6/)) to fix the Jitpack import issue for the `UsbSerial` dependency.

Related issue: #118